### PR TITLE
Replace meshio references by pytest-codeblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://github.com/nschloe/meshio"><img alt="meshio" src="https://nschloe.github.io/pytest-codeblocks/logo.svg" width="60%"></a>
+  <a href="https://github.com/nschloe/pytest-codeblocks"><img alt="pytest-codeblocks" src="https://nschloe.github.io/pytest-codeblocks/logo.svg" width="60%"></a>
   <p align="center">Test code blocks in your READMEs.</p>
 </p>
 


### PR DESCRIPTION
Hi, I noticed the pytest-codeblocks logo links to the meshio page, rather than the pytest-codeblocks page. This updates both the URL and the alt text to `pytest-codeblocks` rather than `meshio`.

I assume this is because part of the readme was copied from meshio, and it didn't get updated. If it indeed was a conscious choice -- well, feel free to ignore this PR...

